### PR TITLE
Use setuptools instead of distutils.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,6 @@ python:
 # command to install dependencies
 install:
     - pip install .
-    - pip install doctest-ignore-unicode
+    - pip install -r requirements.txt
 # command to run tests
 script: make test

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+argparse==1.2.1
+coverage==3.7.1
+doctest-ignore-unicode==0.1.2
+nose==1.3.6
+pyflakes==0.8.1
+wsgiref==0.1.2

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python
-
-from distutils.core import setup
+from setuptools import setup
 
 setup(
     name='travesty',
@@ -8,8 +6,12 @@ setup(
     license='BSD',
     author="Daniel Lepage",
     author_email="dplepage@gmail.com",
-    packages=['travesty','travesty.cantrips', 'travesty.document'],
-    long_description="""
+    packages=[
+        'travesty',
+        'travesty.cantrips',
+        'travesty.document',
+    ],
+    long_description="""\
 =======================================
  Travesty: Graph Traversal Dispatchers
 =======================================
@@ -25,13 +27,13 @@ See README.rst for more info.
 """,
     url='https://github.com/dplepage/travesty',
     install_requires=[
-        'vertigo'
+        'vertigo',
     ],
     test_requires=[
-        'doctest-ignore-unicode'
+        'doctest-ignore-unicode',
     ],
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Programming Language :: Python :: 2",
-    ]
+    ],
 )


### PR DESCRIPTION
setup.py already included keyword arguments for `setuptools`
like `intstall_requires`, but was still using `distutils.core`
which ignored that argument.
